### PR TITLE
fix: add patch for QML cache reload crash

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+qt6-declarative (6.8.0+dfsg-0deepin6) unstable; urgency=medium
+
+  * chore: Update version to 6.8.0+dfsg-0deepin6
+  * fix: add patch for QML cache reload crash
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Tue, 23 Dec 2025 13:38:14 +0800
+
 qt6-declarative (6.8.0+dfsg-0deepin5) unstable; urgency=medium
 
   * Update CVE patches.

--- a/debian/patches/fix-qml-cache-reload-crush-0003.patch
+++ b/debian/patches/fix-qml-cache-reload-crush-0003.patch
@@ -1,0 +1,61 @@
+Index: qt6-declarative/src/qml/qml/qqmlpropertycachecreator_p.h
+===================================================================
+--- qt6-declarative.orig/src/qml/qml/qqmlpropertycachecreator_p.h
++++ qt6-declarative/src/qml/qml/qqmlpropertycachecreator_p.h
+@@ -289,11 +289,12 @@ inline QQmlError QQmlPropertyCacheCreato
+     };
+ 
+     const CompiledObject *obj = objectContainer->objectAt(objectIndex);
++    auto *inheritedTypeRef = objectContainer->resolvedType(obj->inheritedTypeNameIndex);
+     bool needVMEMetaObject = isVMERequired == VMEMetaObjectIsRequired::Always || obj->propertyCount() != 0 || obj->aliasCount() != 0
+             || obj->signalCount() != 0 || obj->functionCount() != 0 || obj->enumCount() != 0
+             || ((obj->hasFlag(QV4::CompiledData::Object::IsComponent)
+                  || (objectIndex == 0 && isAddressable(objectContainer->url())))
+-                && !objectContainer->resolvedType(obj->inheritedTypeNameIndex)->isFullyDynamicType());
++                && inheritedTypeRef && !inheritedTypeRef->isFullyDynamicType());
+ 
+     if (!needVMEMetaObject) {
+         auto binding = obj->bindingsBegin();
+@@ -309,7 +310,10 @@ inline QQmlError QQmlPropertyCacheCreato
+                     if (!propertyCaches->needsVMEMetaObject(context.referencingObjectIndex)) {
+                         const CompiledObject *obj = objectContainer->objectAt(context.referencingObjectIndex);
+                         auto *typeRef = objectContainer->resolvedType(obj->inheritedTypeNameIndex);
+-                        Q_ASSERT(typeRef);
++                        if (!typeRef) {
++                            return qQmlCompileError(binding->location, QQmlPropertyCacheCreatorBase::tr(
++                                    "Type not found, cache may be stale"));
++                        }
+                         QQmlPropertyCache::ConstPtr baseTypeCache = typeRef->createPropertyCache();
+                         QQmlError error = baseTypeCache
+                             ? createMetaObject(context.referencingObjectIndex, obj, baseTypeCache)
+@@ -387,7 +391,14 @@ inline QQmlPropertyCache::ConstPtr QQmlP
+         return context.instantiatingPropertyCache();
+     } else if (obj->inheritedTypeNameIndex != 0) {
+         auto *typeRef = objectContainer->resolvedType(obj->inheritedTypeNameIndex);
+-        Q_ASSERT(typeRef);
++        if (!typeRef) {
++            // Type not found - likely stale cache referencing a removed/renamed type
++            *error = qQmlCompileError(
++                obj->location,
++                QQmlPropertyCacheCreatorBase::tr("Type '%1' not found, cache may be stale.")
++                    .arg(stringAt(obj->inheritedTypeNameIndex)));
++            return nullptr;
++        }
+ 
+         if (typeRef->isFullyDynamicType()) {
+             if (obj->propertyCount() > 0 || obj->aliasCount() > 0) {
+@@ -415,7 +426,13 @@ inline QQmlPropertyCache::ConstPtr QQmlP
+         if (binding->isAttachedProperty()) {
+             auto *typeRef = objectContainer->resolvedType(
+                     binding->propertyNameIndex);
+-            Q_ASSERT(typeRef);
++            if (!typeRef) {
++                *error = qQmlCompileError(
++                    binding->location,
++                    QQmlPropertyCacheCreatorBase::tr("Attached type '%1' not found, cache may be stale.")
++                        .arg(stringAt(binding->propertyNameIndex)));
++                return nullptr;
++            }
+             QQmlType qmltype = typeRef->type();
+             if (!qmltype.isValid()) {
+                 imports->resolveType(

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 
 CVE-2025-12385-qtdeclarative-6.8-0001.patch
 CVE-2025-12385-qtdeclarative-6.8-0002.patch
+fix-qml-cache-reload-crush-0003.patch


### PR DESCRIPTION
Add a new patch to handle stale cache references that cause crashes during QML cache reloading. The patch adds null checks for type references and provides proper error messages when types are not found, preventing assertion failures and improving error handling in the Qt Declarative module.

bug: https://pms.uniontech.com/bug-view-344855.html