### PR TITLE
fix: update CVE-patch 2025-14576

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qt6-declarative (6.8.0+dfsg-0deepin7) unstable; urgency=medium
+
+  * update cve patch. 
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Wed, 24 Dec 2025 14:29:46 +0800
+
 qt6-declarative (6.8.0+dfsg-0deepin6) unstable; urgency=medium
 
   * chore: Update version to 6.8.0+dfsg-0deepin6

--- a/debian/patches/Sanitize-source-string-used-in-output.patch
+++ b/debian/patches/Sanitize-source-string-used-in-output.patch
@@ -1,0 +1,41 @@
+Author: Tian Shilin<tianshilin@uniontech.com>
+Date:   Wed Dec 24 14:32:00 2025
+Subject: VectorImage: Sanitize source string used in output
+Upstream: https://codereview.qt-project.org/c/qt/qtdeclarative/+/697273
+
+---
+
+Index: qt6-declarative/src/quickvectorimage/generator/qsvgvisitorimpl.cpp
+===================================================================
+--- qt6-declarative.orig/src/quickvectorimage/generator/qsvgvisitorimpl.cpp
++++ qt6-declarative/src/quickvectorimage/generator/qsvgvisitorimpl.cpp
+@@ -1041,9 +1041,28 @@ void QSvgVisitorImpl::visitDocumentNodeE
+     m_generator->generateRootNode(info);
+ }
+ 
++static QString scrub(const QString &raw)
++{
++    QString res(raw.left(80));
++
++    if (!res.isEmpty()) {
++        constexpr QLatin1StringView legalSymbols("_-.:"); // Only valid SVG id characters
++        qsizetype i = 0;
++        do {
++            if (res.at(i).isLetterOrNumber() || legalSymbols.contains(res.at(i)))
++                i++;
++            else
++                res.remove(i, 1);
++        } while (i < res.size());
++    }
++
++    return res;
++}
++
+ void QSvgVisitorImpl::fillCommonNodeInfo(const QSvgNode *node, NodeInfo &info)
+ {
+-    info.nodeId = node->nodeId();
++    const QString nodeId = scrub(node->nodeId());
++    info.nodeId = nodeId;
+     info.typeName = node->typeName();
+     info.isDefaultTransform = node->style().transform.isDefault();
+     info.transform = !info.isDefaultTransform ? node->style().transform->qtransform() : QTransform();

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -2,3 +2,4 @@
 CVE-2025-12385-qtdeclarative-6.8-0001.patch
 CVE-2025-12385-qtdeclarative-6.8-0002.patch
 fix-qml-cache-reload-crush-0003.patch
+Sanitize-source-string-used-in-output.patch


### PR DESCRIPTION
log: Source string is used as object name in output, so we sanitize it to make sure it does not contain illegal characters. SVG already mandates a limited character set here, but rather than trust the parser we sanitize before passing to the generator like the Lottie visitor does.

upsteam: https://codereview.qt-project.org/c/qt/qtdeclarative/+/697273