### PR TITLE
fix(qml): add error handling for invalid timestamp in verifyHeader

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+qt6-declarative (6.8.0+dfsg-0deepin9) unstable; urgency=medium
+
+  * chore: Update version to 6.8.0+dfsg-0deepin9
+  * fix: add error handling for invalid timestamp in verifyHeader
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Fri, 26 Dec 2025 13:29:34 +0800
+
 qt6-declarative (6.8.0+dfsg-0deepin8) unstable; urgency=medium
 
   * update cve patch. 

--- a/debian/patches/fix-qml-cache-invalid-timestamp-handle.patch
+++ b/debian/patches/fix-qml-cache-invalid-timestamp-handle.patch
@@ -1,0 +1,23 @@
+Index: qt6-declarative/src/qml/common/qv4compileddata.cpp
+===================================================================
+--- qt6-declarative.orig/src/qml/common/qv4compileddata.cpp
++++ qt6-declarative/src/qml/common/qv4compileddata.cpp
+@@ -58,11 +58,14 @@ bool Unit::verifyHeader(QDateTime expect
+     if (sourceTimeStamp) {
+         // Files from the resource system do not have any time stamps, so fall back to the application
+         // executable.
+-        if (!expectedSourceTimeStamp.isValid())
++        if (!expectedSourceTimeStamp.isValid()) {
+             expectedSourceTimeStamp = QFileInfo(QCoreApplication::applicationFilePath()).lastModified();
+-
+-        if (expectedSourceTimeStamp.isValid()
+-            && expectedSourceTimeStamp.toMSecsSinceEpoch() != sourceTimeStamp) {
++            if (!expectedSourceTimeStamp.isValid()) {
++                *errorString = QStringLiteral("Failed to get valid timestamp from application executable");
++                return false;
++            }
++        }
++        if (expectedSourceTimeStamp.toMSecsSinceEpoch() != sourceTimeStamp) {
+             *errorString = QStringLiteral("QML source file has a different time stamp than cached file.");
+             return false;
+         }

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -4,3 +4,4 @@ CVE-2025-12385-qtdeclarative-6.8-0002.patch
 fix-qml-cache-reload-crush-0003.patch
 Sanitize-source-string-used-in-output.patch
 QTCR-4340300-PS3.diff
+fix-qml-cache-invalid-timestamp-handle.patch


### PR DESCRIPTION
when the last modified time of the application is invalid, the timestamp verification function may fail. Regenerate the cache when it is invalid.

bug: https://pms.uniontech.com/bug-view-344855.html