### PR TITLE
fix: Fix QML touchscreen multi-finger swipe not working

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+qt6-declarative (6.8.0+dfsg-0deepin10) unstable; urgency=medium
+
+  * chore: Update version to 6.8.0+dfsg-0deepin10
+  * fix: Fix QML touchscreen multi-finger swipe not working
+
+ -- lvpeilong <lvpeilong@uniontech.com>  Sat, 27 Dec 2025 09:15:42 +0800
+
 qt6-declarative (6.8.0+dfsg-0deepin9) unstable; urgency=medium
 
   * chore: Update version to 6.8.0+dfsg-0deepin9

--- a/debian/patches/Fix-QML-touchscreen-multi-finger-swipe-not-working.patch
+++ b/debian/patches/Fix-QML-touchscreen-multi-finger-swipe-not-working.patch
@@ -1,0 +1,62 @@
+Index: qt6-declarative/src/quick/items/qquickflickable.cpp
+===================================================================
+--- qt6-declarative.orig/src/quick/items/qquickflickable.cpp
++++ qt6-declarative/src/quick/items/qquickflickable.cpp
+@@ -1375,14 +1375,13 @@ void QQuickFlickablePrivate::handleMoveE
+     const QVector2D velocity = firstPointLocalVelocity(event);
+     bool overThreshold = false;
+ 
+-    if (event->pointCount() == 1) {
+-        if (q->yflick())
+-            overThreshold |= QQuickDeliveryAgentPrivate::dragOverThreshold(deltas.y(), Qt::YAxis, firstPoint);
+-        if (q->xflick())
+-            overThreshold |= QQuickDeliveryAgentPrivate::dragOverThreshold(deltas.x(), Qt::XAxis, firstPoint);
+-    } else {
+-        qCDebug(lcFilter) << q->objectName() << "ignoring multi-touch" << event;
+-    }
++    // Always calculate drag threshold based on the first (primary) touch point,
++    // regardless of how many fingers are touching. This matches Qt5 behavior where
++    // synthesized mouse events only tracked the primary touch point.
++    if (q->yflick())
++        overThreshold |= QQuickDeliveryAgentPrivate::dragOverThreshold(deltas.y(), Qt::YAxis, firstPoint);
++    if (q->xflick())
++        overThreshold |= QQuickDeliveryAgentPrivate::dragOverThreshold(deltas.x(), Qt::XAxis, firstPoint);
+ 
+     drag(currentTimestamp, event->type(), pos, deltas, overThreshold, false, false, velocity);
+ }
+@@ -2694,17 +2693,20 @@ bool QQuickFlickable::filterPointerEvent
+     // If a touch event contains a new press point, don't steal right away: watch the movements for a while
+     if (isTouch && static_cast<QTouchEvent *>(event)->touchPointStates().testFlag(QEventPoint::State::Pressed))
+         d->stealMouse = false;
+-    // If multiple touchpoints are within bounds, don't grab: it's probably meant for multi-touch interaction in some child
+-    if (event->pointCount() > 1) {
+-        qCDebug(lcFilter) << objectName() << "ignoring multi-touch" << event << "for" << receiver;
+-        d->stealMouse = false;
++    // Continue filtering based on the first (primary) touch point even during multi-touch,
++    // to allow two-finger scrolling (matching Qt5 behavior where synthesized mouse events
++    // always tracked the primary touch point). Child items that need multi-touch gestures
++    // (e.g. PinchArea) are still protected via the receiverKeepsGrab mechanism below.
++    const bool isMultiTouch = event->pointCount() > 1;
++    if (isMultiTouch) {
++        qCDebug(lcFilter) << objectName() << "filtering multi-touch (primary point)" << event << "for" << receiver;
+     } else {
+         qCDebug(lcFilter) << objectName() << "filtering" << event << "for" << receiver;
+     }
+ 
+     const auto &firstPoint = event->points().first();
+ 
+-    if (event->pointCount() == 1 && event->exclusiveGrabber(firstPoint) == this) {
++    if (event->exclusiveGrabber(firstPoint) == this) {
+         // We have an exclusive grab (since we're e.g dragging), but at the same time, we have
+         // a child with a passive grab (which is why this filter is being called). And because
+         // of that, we end up getting the same pointer events twice; First in our own event
+@@ -2767,7 +2769,8 @@ bool QQuickFlickable::filterPointerEvent
+             event->setExclusiveGrabber(firstPoint, this);
+         }
+ 
+-        const bool filtered = !receiverRelinquishGrab && (stealThisEvent || d->delayedPressEvent || receiverDisabled);
++        const bool filtered = !receiverRelinquishGrab && (stealThisEvent || d->delayedPressEvent || receiverDisabled
++                                                          || (isMultiTouch && !receiverKeepsGrab));
+         if (filtered) {
+             event->setAccepted(true);
+         }

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -5,3 +5,4 @@ fix-qml-cache-reload-crush-0003.patch
 Sanitize-source-string-used-in-output.patch
 QTCR-4340300-PS3.diff
 fix-qml-cache-invalid-timestamp-handle.patch
+Fix-QML-touchscreen-multi-finger-swipe-not-working.patch


### PR DESCRIPTION
The patch modifies QQuickFlickable's touch event handling to support multi-finger scrolling on touchscreens. Previously, the code explicitly ignored multi-touch events (event->pointCount() > 1), preventing two- finger scrolling from working. The fix changes the logic to always calculate drag thresholds based on the primary touch point, regardless of the number of fingers, matching Qt5 behavior where synthesized mouse events tracked only the primary point. This allows Flickable to respond to multi-finger swipes while still allowing child items like PinchArea to handle multi-touch gestures via the receiverKeepsGrab mechanism.

Log: Fixed touchscreen multi-finger swipe gestures not working in QML applications

Influence:
1. Test two-finger scrolling on touchscreen devices with QML applications using Flickable
2. Verify that single-finger scrolling continues to work correctly
3. Test that multi-touch gestures in child items (e.g., PinchArea) still function properly
4. Verify touch event filtering and grab behavior in complex touch scenarios
5. Test edge cases with multiple touch points and different gesture combinations

fix: 修复QML触摸屏多指滑动不工作的问题

该补丁修改了QQuickFlickable的触摸事件处理逻辑，以支持触摸屏上的多指滚
动。之前，代码明确忽略多点触控事件（event->pointCount() > 1），导致双指
滚动无法工作。修复后的逻辑改为始终基于主触摸点计算拖动阈值，无论手指数量
多少，这与Qt5的行为相匹配（合成鼠标事件仅跟踪主触摸点）。这使得Flickable
能够响应多指滑动，同时仍允许子项（如PinchArea）通过receiverKeepsGrab机制
处理多点触控手势。

Log: 修复了QML应用程序中触摸屏多指滑动手势不工作的问题

Influence:
1. 在使用Flickable的QML应用程序中测试触摸屏上的双指滚动功能
2. 验证单指滚动功能是否继续正常工作
3. 测试子项中的多点触控手势（如PinchArea）是否仍能正常使用
4. 验证复杂触摸场景下的触摸事件过滤和抓取行为
5. 测试多点触摸和不同手势组合的边缘情况

PMS: BUG-351191