### PR TITLE
fix: restore focus after closing popup window

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qt6-declarative (6.8.0+dfsg-0deepin13) unstable; urgency=medium
+
+  * fix: restore focus after closing popup window
+
+ -- lvpeilong <lvpeilong@uniontech.com>  Tue, 16 Jun 2026 13:51:17 +0800
+
 qt6-declarative (6.8.0+dfsg-0deepin12) unstable; urgency=medium
 
   * fix: add multi-seat event support for QQuickDeliveryAgent

--- a/debian/patches/fix-popup-focus-restoration-for-focused-child.patch
+++ b/debian/patches/fix-popup-focus-restoration-for-focused-child.patch
@@ -1,0 +1,38 @@
+Author: Robertkill <lvpeilong@uniontech.com>
+Date:   Tue Jun 16 13:21:37 2026
+Subject: fix popup focus restoration when a popup child owns focus
+
+When a Popup.Window is closed while focus is held by a child item,
+QQuickPopup only checks the popup item itself and misses the focused
+descendant. As a result the original window focus is not restored after
+the popup closes.
+
+Record focus ownership for focused descendants and reactivate the window
+before restoring the previous focus item.
+
+---
+
+Index: qt6-declarative/src/quicktemplates/qquickpopup.cpp
+===================================================================
+--- qt6-declarative.orig/src/quicktemplates/qquickpopup.cpp
++++ qt6-declarative/src/quicktemplates/qquickpopup.cpp
+@@ -800,5 +800,8 @@ bool QQuickPopupPrivate::prepareExitTransition()
+         // able to check it in finalizeExitTransition.
+         if (!hadActiveFocusBeforeExitTransition) {
+             const auto *da = QQuickItemPrivate::get(popupItem)->deliveryAgentPrivate();
+-            hadActiveFocusBeforeExitTransition = popupItem->hasActiveFocus() || (da && da->focusTargetItem() == popupItem);
++            QQuickItem *focusTarget = da ? da->focusTargetItem() : nullptr;
++            hadActiveFocusBeforeExitTransition = popupItem->hasActiveFocus()
++                    || focusTarget == popupItem
++                    || (focusTarget && popupItem->isAncestorOf(focusTarget));
+         }
+@@ -852,6 +855,8 @@ void QQuickPopupPrivate::finalizeExitTransition()
+             auto *contentItem = appWindow ? appWindow->contentItem() : window->contentItem();
+             auto *overlay = QQuickOverlay::overlay(window);
+             auto *overlayPrivate = QQuickOverlayPrivate::get(overlay);
++            if (usePopupWindow())
++                window->requestActivate();
+             if (!contentItem->scopedFocusItem()
+                 && !overlayPrivate->lastActiveFocusItem.isNull()) {
+                 overlayPrivate->lastActiveFocusItem->setFocus(true, Qt::OtherFocusReason);
+         }

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -8,3 +8,4 @@ fix-qml-cache-invalid-timestamp-handle.patch
 Fix-QML-touchscreen-multi-finger-swipe-not-working.patch
 fix-gc-Assume-less-if-hasConstWrapper-is-set.path
 qt6-declarative-add-multi-seat-event.patch
+fix-popup-focus-restoration-for-focused-child.patch


### PR DESCRIPTION
## Summary
- Add a Debian quilt patch for `QQuickPopup` focus restoration.
- Treat focused popup descendants as popup-owned focus before exit transition.
- Reactivate the parent window and force restore the previous focus item after the popup closes.

## Verification
- Deployed the final minimal Qt library to the debug machine 10.20.9.188 and verified the DCC Popup.Window focus restoration.
- `QUILT_PATCHES=debian/patches quilt push -a` / `quilt pop -a` passed.
- `cmake --build build --target QuickTemplates2 -j100` passed with icecc enabled.
- `/usr/lib/qt6/bin/qmltestrunner -input /tmp/tst_popup_window_focus_trace.qml -platform offscreen` passed: 3 passed, 0 failed.

PMS: BUG-366067
