### PR TITLE
fix(flickable): prevent edge scroll jump-back

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qt6-declarative (6.8.0+dfsg-0deepin13) unstable; urgency=medium
+
+  * fix: add multi-seat event support for QQuickDeliveryAgent
+
+ -- Kun Zhang <zhangkun2@uniontech.com>  Wed, 15 Jun 2026 15:18:45 +0800
+
 qt6-declarative (6.8.0+dfsg-0deepin12) unstable; urgency=medium
 
   * fix: add multi-seat event support for QQuickDeliveryAgent

--- a/debian/patches/QQuickFlickable-fix-jump-back-when-scrolling-to-edge.patch
+++ b/debian/patches/QQuickFlickable-fix-jump-back-when-scrolling-to-edge.patch
@@ -1,0 +1,40 @@
+From: Wang Chuan <ouchuanm@outlook.com>
+Date: Mon, 2 Jun 2025 20:18:38 +0800
+Subject: QQuickFlickable: fix jump back when scrolling to edge
+
+Since de591d440c2f43a7e94ef4c93db757d254fa7947, vMoved/hMoved are used
+to check if it is the first move in dragging. However they can be reset
+to false during dragging, causing the content to jump back when scrolling
+to the edge of the Flickable.
+
+Check the dragging state as well before resetting dragStartOffset.
+
+Origin: upstream, https://github.com/qt/qtdeclarative/commit/de1e849d09466aed10822077012789a0f2f126c1
+Bug: https://bugreports.qt.io/browse/QTBUG-137323
+Applied-Upstream: de1e849d09466aed10822077012789a0f2f126c1
+---
+ src/quick/items/qquickflickable.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/quick/items/qquickflickable.cpp b/src/quick/items/qquickflickable.cpp
+index b5ab2ab7a..6c45de69a 100644
+--- a/src/quick/items/qquickflickable.cpp
++++ b/src/quick/items/qquickflickable.cpp
+@@ -1182,7 +1182,7 @@ void QQuickFlickablePrivate::drag(qint64 currentTimestamp, QEvent::Type eventTyp
+     if (q->yflick()) {
+         qreal dy = deltas.y();
+         if (overThreshold || elapsedSincePress > 200) {
+-            if (!vMoved)
++            if (!vMoved && !vData.dragging)
+                 vData.dragStartOffset = dy;
+             qreal newY = dy + vData.pressPos - (syncDrag ? 0 : vData.dragStartOffset);
+             // Recalculate bounds in case margins have changed, but use the content
+@@ -1258,7 +1258,7 @@ void QQuickFlickablePrivate::drag(qint64 currentTimestamp, QEvent::Type eventTyp
+     if (q->xflick()) {
+         qreal dx = deltas.x();
+         if (overThreshold || elapsedSincePress > 200) {
+-            if (!hMoved)
++            if (!hMoved && !hData.dragging)
+                 hData.dragStartOffset = dx;
+             qreal newX = dx + hData.pressPos - (syncDrag ? 0 : hData.dragStartOffset);
+             const qreal minX = hData.dragMinBound + hData.startMargin;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -8,3 +8,4 @@ fix-qml-cache-invalid-timestamp-handle.patch
 Fix-QML-touchscreen-multi-finger-swipe-not-working.patch
 fix-gc-Assume-less-if-hasConstWrapper-is-set.path
 qt6-declarative-add-multi-seat-event.patch
+QQuickFlickable-fix-jump-back-when-scrolling-to-edge.patch


### PR DESCRIPTION
1. Backport the upstream QQuickFlickable fix for edge scrolling.
2. Avoid resetting dragStartOffset while a horizontal or vertical drag is active.
3. Register the new Debian patch in the patch series.

Log: Prevent Flickable content from jumping back when scrolling to an edge.

fix(flickable): 修复边缘滚动回弹问题

1. 回移植上游 QQuickFlickable 边缘滚动修复。
2. 避免在横向或纵向拖拽过程中重置 dragStartOffset。
3. 将新的 Debian 补丁加入补丁序列。

Log: 修复 Flickable 内容滚动到边缘时跳回的问题。
PMS: TASK-391445